### PR TITLE
Restore search term after a login redirect.

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -19,6 +19,24 @@ class App extends Component {
     this.search = this.search.bind(this);
   }
 
+  componentDidMount() {
+    // TODO: break this functionality out into a new function called parseUserAuthorization()
+    Spotify.getAccessToken();
+    const searchTerm = sessionStorage.getItem('searchTerm');
+    if (searchTerm) {
+      // Simply setting the input value with "input.value =" won't work as it
+      // doesn't trigger the React onChange event handler so we have to do this instead.
+      const searchTermInput = document.getElementById('searchTerm');
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+      const event = new Event('input', { bubbles: true });
+      setValue.call(searchTermInput, searchTerm);
+      searchTermInput.dispatchEvent(event);
+
+      this.search(searchTerm);
+      sessionStorage.removeItem('searchTerm');
+    }
+  }
+
   addTrack(track) {
     if (this.state.playlistTracks.find(savedTrack => savedTrack.id === track.id)) {
       return;

--- a/src/Components/SearchBar/SearchBar.js
+++ b/src/Components/SearchBar/SearchBar.js
@@ -21,7 +21,7 @@ export class SearchBar extends React.Component {
   render() {
     return (
       <div className="SearchBar">
-        <input placeholder="Enter A Song, Album, or Artist" onChange={this.handleTermChange}/>
+        <input id="searchTerm" placeholder="Enter A Song, Album, or Artist" onChange={this.handleTermChange}/>
         <a onClick={this.search}>SEARCH</a>
       </div>
     );

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -21,8 +21,7 @@ const Spotify = {
       window.history.pushState('Access Token', null, '/');
       return currentAccessToken;
     } else {
-      console.log('No access token found. Redirecting.');
-      window.location.replace(authorizationUrl);
+      console.log('No access token found.');
       return '';
     }
   },
@@ -30,6 +29,8 @@ const Spotify = {
     let accessToken = await this.getAccessToken();
     if (!accessToken) {
       console.log('No access token present.');
+      sessionStorage.setItem('searchTerm', searchTerm);
+      window.location.replace(authorizationUrl);
       return [];
     }
 
@@ -72,6 +73,8 @@ const Spotify = {
     let accessToken = await this.getAccessToken();
     if (!accessToken) {
       console.log('No access token present.');
+      // Save playlist information to session storage here
+      window.location.replace(authorizationUrl);
       return;
     }
 


### PR DESCRIPTION
This fixes the issue where a search request is not performed after completing login to the users Spotify account.